### PR TITLE
Master

### DIFF
--- a/Platform/platform.h
+++ b/Platform/platform.h
@@ -52,7 +52,7 @@
 	typedef PlatformTypes::u_int_64 U64;
 	typedef PlatformTypes::A_CHAR ACHAR;
 	typedef PlatformTypes::W_CHAR WCHAR;
-	typedef PlatformTypes::T_CHAR TCHAR;
+	typedef PlatformTypes::T_CHAR TWCHAR;
 	typedef PlatformTypes::char_8 UTF8;
 	typedef PlatformTypes::char_16 UTF16;
 	typedef PlatformTypes::char_32 UTF32;


### PR DESCRIPTION
Changed typedef TCHAR in platform.h to avoid clashes with Windows Include typedef in tchar.h (it now compiles in VS)